### PR TITLE
UU3-16621 - Migrate the current API documentation to Swagger2

### DIFF
--- a/lib/apipie/application.rb
+++ b/lib/apipie/application.rb
@@ -278,7 +278,7 @@ module Apipie
            result[k] = v if k == resource_name
          end
          result
-       end
+      end
 
       @swagger_generator.generate_from_resources(version,_resources, method_name, lang, clear_warnings)
     end

--- a/lib/apipie/configuration.rb
+++ b/lib/apipie/configuration.rb
@@ -179,7 +179,7 @@ module Apipie
       @swagger_suppress_warnings = false #[105,100,102]
       @swagger_api_host = "localhost:3000"
       @swagger_generate_x_computed_id_field = false
-      @swagger_allow_additional_properties_in_response = false
+      @swagger_allow_additional_properties_in_response = true
       @swagger_responses_use_refs = true
     end
   end

--- a/lib/apipie/validator.rb
+++ b/lib/apipie/validator.rb
@@ -387,6 +387,31 @@ module Apipie
 
 
     # special type of validator: we say that it's not specified
+    class StringValidator < BaseValidator
+
+      def validate(value)
+        self.class.validate(value)
+      end
+
+      def self.build(param_description, argument, options, block)
+        if argument == :string
+          self.new(param_description)
+        end
+      end
+
+      def description
+        "Must be a alphanumeric string."
+      end
+
+      def expected_type
+        'string'
+      end
+
+      def self.validate(value)
+        value.to_s =~ /([0-9a-fA-F]{32}|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/
+      end
+    end
+
     class UndefValidator < BaseValidator
 
       def validate(value)


### PR DESCRIPTION
added apipie_id's to swagger export, added validator for path id's, changed name format in swagger export.

Item changed | Reason
------------ | -------------
swagger_allow_additional_properties_in_response = true | this is in apipies config file, it allows additional properties.
Sorted the swagger paths, and swagger tags by name | For an organized output in the json file, most web apps for swagger follow the json's (yaml) file ordering.
resource.sort_by was added | from the same reason as above
resource._name instead of resource._id | this is the eventually displayed name and resource._id was no good, resource._name in the other hand was what we wanted.
swagger[:consumes] | changed to both application/json and application/x-www-form-urlencoded so in apiary the request parameters attributes will be shown in a clear way, and that the real method will be mentioned (application/json)
added id: ruby_method.resource._id | for crossing with the examples in the examples file which contains this parameter for each example.
Added  class StringValidator < BaseValidator | was added to validate and format correctly path variables (group_id, user_id etc).
